### PR TITLE
Add / Remove 'active' class from slides

### DIFF
--- a/slidr.js
+++ b/slidr.js
@@ -447,6 +447,7 @@
         fx.init(_, _.current, 'fade');
         fx.animate(_, _.current, 'fade', 'in');
         _.displayed = true;
+        classname(_.slides[_.current].el, 'add', 'active'); // add active class
         actions.controls(_, _.settings['controls']);
         if (!!_.settings['breadcrumbs']) actions.breadcrumbs(_);
       }
@@ -474,13 +475,15 @@
 
     // Go to a target slide.
     go: function(_, el, outdir, indir, opt_outtrans, opt_intrans) {
-      if (_.current && el) {
+      if (_.current && el) { 
         var intrans = opt_intrans || transition.get(_, el, 'in', indir);
         var outtrans = opt_outtrans || transition.get(_, _.current, 'out', outdir);
         var meta = callback.meta(_, _.current, el, outdir, indir, outtrans, intrans);
         callback.before(_, meta);
+        classname(_.slides[_.current].el, 'rm', 'active'); // remove active class
         transition.apply(_, el, 'in', indir, intrans);
         transition.apply(_, _.current, 'out', outdir, outtrans);
+        classname(_.slides[el].el, 'add', 'active'); // add active class
         callback.after(_, meta);
         _.current = el;
         controls.update(_);

--- a/slidr.js
+++ b/slidr.js
@@ -450,6 +450,7 @@
         classname(_.slides[_.current].el, 'add', 'active'); // add active class
         actions.controls(_, _.settings['controls']);
         if (!!_.settings['breadcrumbs']) actions.breadcrumbs(_);
+        if (typeof _.created === 'function') _.created(_); // created callback function
       }
     },
 
@@ -1213,7 +1214,7 @@
   };
 
   // The Slidr constructor.
-  var Slidr = function(id, el, settings) {
+  var Slidr = function(id, el, settings, created) {
 
     var _ = {
       // Slidr id.
@@ -1256,7 +1257,10 @@
       crumbs: {},
 
       // Reference to the Slidr controller navigators.
-      nav: { 'up': null, 'down': null, 'left': null, 'right': null }
+      nav: { 'up': null, 'down': null, 'left': null, 'right': null },
+
+      // callback after Slidr instance has been created
+      created: created
     };
 
     var api = {
@@ -1445,8 +1449,9 @@
      * Calling create on the same element twice returns the already instantiated Slidr.
      * @param {string} id The element id to turn into a Slidr.
      * @param {Object=} opt_settings Settings to apply.
+     * @param {Object=} created Callback function after slidr has been created.
      */
-    'create': function(id, opt_settings) {
+    'create': function(id, opt_settings, created) {
       var el = document.getElementById(id);
       if (!el) {
         console.warn('[Slidr] Could not find element with id [' + id + '].');
@@ -1454,7 +1459,7 @@
       }
       var settings = extend(DEFAULTS, opt_settings || {});
       settings['timing'] = extend(TIMING, settings['timing']);
-      INSTANCES[id] = INSTANCES[id] || new Slidr(id, el, settings);
+      INSTANCES[id] = INSTANCES[id] || new Slidr(id, el, settings, created);
       return INSTANCES[id];
     }
   };

--- a/slidr.js
+++ b/slidr.js
@@ -571,7 +571,7 @@
 
     // Create controls container.
     create: function(_) {
-      if (_.slidr && !_.controls && _.settings.controls != 'none') {
+      if (_.slidr && !_.controls) {
         _.controls = css(classname(createEl('aside', { 'id': controls.cls.id(_) }), 'add', 'disabled'), {
           'opacity': '0',
           'filter': 'alpha(opacity=0)',
@@ -680,8 +680,7 @@
 
     // Update controls.
     update: function(_) {
-      if(_.settings.controls != 'none')
-        for (var n in _.nav) classname(_.nav[n], actions.canSlide(_, n) ? 'rm' : 'add', 'disabled');
+      for (var n in _.nav) classname(_.nav[n], actions.canSlide(_, n) ? 'rm' : 'add', 'disabled');
     }
   };
 
@@ -692,7 +691,7 @@
 
     // Initialize breadcrumbs container.
     init: function(_) {
-      if (_.slidr && !_.breadcrumbs && _.settings.breadcrumbs) {
+      if (_.slidr && !_.breadcrumbs) {
         _.breadcrumbs = css(classname(createEl('aside', { 'id': breadcrumbs.cls.id(_) }), 'add', 'disabled'), {
           'opacity': '0',
           'filter': 'alpha(opacity=0)',
@@ -781,14 +780,13 @@
 
     // Update breadcrumbs.
     update: function(_, el, type) {
-      if(_.settings.breadcrumbs)
-        classname(_.crumbs[el].el, type === 'in' ? 'add' : 'rm', 'active');
+      classname(_.crumbs[el].el, type === 'in' ? 'add' : 'rm', 'active');
     },
 
     // Create breadcrumbs.
     create: function(_) {
       breadcrumbs.init(_);
-      if (_.breadcrumbs && _.settings.breadcrumbs) {
+      if (_.breadcrumbs) {
         var crumbs = {};
         var bounds = { x: { min: 0, max: 0 }, y: { min: 0, max: 0 } };
         breadcrumbs.find(_, crumbs, bounds, _.start, 0, 0);

--- a/slidr.js
+++ b/slidr.js
@@ -571,7 +571,7 @@
 
     // Create controls container.
     create: function(_) {
-      if (_.slidr && !_.controls) {
+      if (_.slidr && !_.controls && _.settings.controls != 'none') {
         _.controls = css(classname(createEl('aside', { 'id': controls.cls.id(_) }), 'add', 'disabled'), {
           'opacity': '0',
           'filter': 'alpha(opacity=0)',
@@ -680,7 +680,8 @@
 
     // Update controls.
     update: function(_) {
-      for (var n in _.nav) classname(_.nav[n], actions.canSlide(_, n) ? 'rm' : 'add', 'disabled');
+      if(_.settings.controls != 'none')
+        for (var n in _.nav) classname(_.nav[n], actions.canSlide(_, n) ? 'rm' : 'add', 'disabled');
     }
   };
 
@@ -691,7 +692,7 @@
 
     // Initialize breadcrumbs container.
     init: function(_) {
-      if (_.slidr && !_.breadcrumbs) {
+      if (_.slidr && !_.breadcrumbs && _.settings.breadcrumbs) {
         _.breadcrumbs = css(classname(createEl('aside', { 'id': breadcrumbs.cls.id(_) }), 'add', 'disabled'), {
           'opacity': '0',
           'filter': 'alpha(opacity=0)',
@@ -780,13 +781,14 @@
 
     // Update breadcrumbs.
     update: function(_, el, type) {
-      classname(_.crumbs[el].el, type === 'in' ? 'add' : 'rm', 'active');
+      if(_.settings.breadcrumbs)
+        classname(_.crumbs[el].el, type === 'in' ? 'add' : 'rm', 'active');
     },
 
     // Create breadcrumbs.
     create: function(_) {
       breadcrumbs.init(_);
-      if (_.breadcrumbs) {
+      if (_.breadcrumbs && _.settings.breadcrumbs) {
         var crumbs = {};
         var bounds = { x: { min: 0, max: 0 }, y: { min: 0, max: 0 } };
         breadcrumbs.find(_, crumbs, bounds, _.start, 0, 0);


### PR DESCRIPTION
Add / Remove 'active' class from slides. Developers can now scope CSS animations and specific styles to active slides.
