### PR TITLE
README.md: fixing a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ aside[id="{slidr-id}-control"] .slidr-control.right:hover {
 }
 ```
 
-Note: controller arrows make use of the `:after` psuedo element.
+Note: controller arrows make use of the `:after` pseudo element.
 To hide the default triangular arrow, use the following CSS:
 
 ```css


### PR DESCRIPTION
'psuedo' was 'pseudo'. :)

I found this typo while I was developing a website with your fantastic tool. Could you fix the documentation please? (I already patched README.md with this)
