### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "slidr",
   "main": "slidr.js",
-  "version": "0.5.0",
   "homepage": "https://github.com/bchanx/slidr",
   "authors": [
     "bchanx <bchanx@gmail.com>"


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property
