### PR TITLE
docs: Fix simple typo, psuedo -> pseudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ aside[id="{slidr-id}-control"] .slidr-control.right:hover {
 }
 ```
 
-Note: controller arrows make use of the `:after` psuedo element.
+Note: controller arrows make use of the `:after` pseudo element.
 To hide the default triangular arrow, use the following CSS:
 
 ```css


### PR DESCRIPTION
There is a small typo in README.md.

Should read `pseudo` rather than `psuedo`.

